### PR TITLE
Fix Docker image tag confusion by explicitly setting BASE_IMAGE for standard build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           context: .
           push: true
+          build-args: BASE_IMAGE=denoland/deno:2.6.4
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The standard build now explicitly sets BASE_IMAGE=denoland/deno:2.6.4 as a
build-arg, matching the pattern used by the hardened build. This ensures:

1. Distinct cache keys between standard and hardened builds
2. Clear differentiation in build configurations
3. Prevents potential cache confusion that could cause the 'latest' tag
   to incorrectly reference the hardened image

Both builds now have explicit BASE_IMAGE build-args:
- Standard: BASE_IMAGE=denoland/deno:2.6.4
- Hardened: BASE_IMAGE=dhi.io/deno:2

This complements the cache scope separation added in eb17de6.